### PR TITLE
Improvements to build process and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ ENV CONFIG_UPDATED 2018-08-10.1202
 COPY build-site.sh check-links-3.py /usr/local/bin/
 COPY bamboo-build.txt /usr/local/etc/
 RUN chmod a+rx /usr/local/bin/build-site.sh /usr/local/bin/check-links-3.py
+RUN chmod a+r /usr/local/etc/bamboo-build.txt
 
 WORKDIR /srv
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 	build-essential \
 	zlib1g-dev \
 # rmagick requires MagickWand libraries
-	libmagickwand-dev \
+ 	libmagickwand-dev \
 # Required when building webp images
 	imagemagick \
 	webp \
 # Required when building nokogiri
 	autoconf \
-# Required by coffeescript
+# Required by autofixer-rails
 	nodejs \
 # Required for Python package installation
 	python3-pip \
@@ -75,6 +75,7 @@ ENV CONFIG_UPDATED 2018-08-10.1202
 ################################################################################
 
 COPY build-site.sh check-links-3.py /usr/local/bin/
+COPY bamboo-build.txt /usr/local/etc/
 RUN chmod a+rx /usr/local/bin/build-site.sh /usr/local/bin/check-links-3.py
 
 WORKDIR /srv

--- a/README.md
+++ b/README.md
@@ -16,7 +16,18 @@ Building has been tested with [Docker Community Edition](https://www.docker.com/
 ### Building
 Build the container in the usual way, e.g.
 
-`docker build --rm -t "linaroits/jekyllsitebuild" .`
+`docker build --rm -t "linaroits/jekyllsitebuild:<tag>" .`
+
+**Important:** If developing a variant of this container, e.g. to add a new package, use a personal tag reference and then specify that tag when running the site building script, e.g.:
+
+`JEKYLLSITEBUILD="personaltag" ./build-site.sh`
+
+If you omit `<tag>`, Docker will default to tagging the container as `latest` which could cause confusion if testing local changes. For that reason, Linaro-provided versions of the jekyllsitebuild container will display the Bamboo build reference at the start of the scripts being run, e.g.:
+
+```
+Built by bamboo.linaro.org: CON-JBC-41
+...
+```
 
 Built containers can also be found on [Docker Hub](https://hub.docker.com/r/linaroits/jekyllsitebuild/tags/) for your convenience.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Build the container in the usual way, e.g.
 If you omit `<tag>`, Docker will default to tagging the container as `latest` which could cause confusion if testing local changes. For that reason, Linaro-provided versions of the jekyllsitebuild container will display the Bamboo build reference at the start of the scripts being run, e.g.:
 
 ```
-Built by bamboo.linaro.org: CON-JBC-41
+Container built by bamboo.linaro.org: CON-JBC-JOB1-43 20190622-1009
 ...
 ```
 

--- a/build-site.sh
+++ b/build-site.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 #
+# If possible, show which container version this is
+if [ -f "/usr/local/etc/bamboo-build.txt" ]; then
+    value=$(</usr/local/etc/bamboo-build.txt)
+    if [ ! -z "$value" ]; then
+        echo "$value"
+    fi
+fi
+#
 # Check we've got defined vars
 if [ -z "$JEKYLL_CONFIG" ]; then
     echo "JEKYLL_CONFIG needs to be set"
@@ -58,4 +66,4 @@ bundle install
 #
 # Build the site
 echo "Building site"
-bundle exec jekyll "$JEKYLL_ACTION" "$HOST" --config "$JEKYLL_CONFIG" JEKYLL_ENV="$JEKYLL_ENV"
+bundle exec jekyll "$JEKYLL_ACTION" "$HOST" --trace --config "$JEKYLL_CONFIG" JEKYLL_ENV="$JEKYLL_ENV"


### PR DESCRIPTION
Introduced the ability for Bamboo to create a file that gets included in the container and then used by the build script to show, when a site is being built, which container version is being used.

Updated README to reflect this information.

Add --trace flag to Jekyll to ensure that if a build fails for whatever reason, we can get a stacktrace to assist with troubleshooting.

After this PR is approved and merged, .gitignore will be updated to ignore the placeholder file "bamboo-build.txt" so that contributors cannot (easily) override that with a fixed value.
