### PR TITLE
Ignore bamboo-build.txt changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bamboo-build.txt


### PR DESCRIPTION
As previously discussed, bamboo-build.txt is being added to .gitignore so that any changes made to the file don't get accidentally committed back to the repository.
