### PR TITLE
Replace JEKYLL_CONFIG with actual value

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -92,5 +92,5 @@ bundle exec jekyll \
  "$JEKYLL_ACTION" \
  "$HOSTING_OPTIONS" \
  --trace \
- --config "$JEKYLL_CONFIG" \
+ --config "_config.yml,_config-$JEKYLL_ENV.yml" \
  JEKYLL_ENV="$JEKYLL_ENV"


### PR DESCRIPTION
We don't use or pass JEKYLL_CONFIG now, so we construct the actual value based on the JEKYLL_ENV value.
