### PR TITLE
Corrected jumbo-jekyll-theme dependency for Linaro.cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,15 +124,13 @@ ENV RUBY_GEMS \
  jumbo-jekyll-theme:3.9.4 \
  # Used by ArmNN
  jumbo-jekyll-theme:4.4.4 \
- # Used by clouc
- jumbo-jekyll-theme:4.4.9 \
  # Used by devicetree, TrustedFirmware
  jumbo-jekyll-theme:4.5.0 \
  # Used by linaro.org
  jumbo-jekyll-theme:4.7.7 \
  # Used by connect, ai
  jumbo-jekyll-theme:5.3.4 \
- # Used by OP-TEE
+ # Used by OP-TEE, Linaro.cloud
  jumbo-jekyll-theme:5.5.1 \
  # Used by devicetree, OP-TEE
  mini_magick:4.9.3 \


### PR DESCRIPTION
Updated the Dockerfile with the correct jumbo-jekyll-theme dependency for Linaro.cloud