### PR TITLE
Get Jekyll to be strict about YAML failures

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -91,6 +91,7 @@ echo "Building site"
 bundle exec jekyll \
  "$JEKYLL_ACTION" \
  "$HOSTING_OPTIONS" \
+ --strict \
  --trace \
  --config "_config.yml,_config-$JEKYLL_ENV.yml" \
  JEKYLL_ENV="$JEKYLL_ENV"


### PR DESCRIPTION
This will cause site builds to fail properly rather than Jekyll continuing regardless and then contributors not understanding why their content isn't appearing.
