### PR TITLE
Add support for passing parameters from host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,3 +156,6 @@ ENV BAMBOO_BUILD=${bamboo_build}
 
 WORKDIR /srv
 EXPOSE 4000
+
+ENTRYPOINT ["/usr/local/bin/build-site.sh"]
+CMD []

--- a/build-site.sh
+++ b/build-site.sh
@@ -92,7 +92,8 @@ echo "Building site"
 bundle exec jekyll \
  "$JEKYLL_ACTION" \
  "$HOSTING_OPTIONS" \
- --strict \
+ --strict_front_matter \
  --trace \
  --config "_config.yml,_config-$JEKYLL_ENV.yml" \
+ "$@"
  JEKYLL_ENV="$JEKYLL_ENV"


### PR DESCRIPTION
Fix `--strict` to `--strict_front_matter`. Specify `ENTRYPOINT` and `CMD` in Dockerfile and pass any command-line arguments from the host through to the script in the container.
