### PR TITLE
Add missing "\"

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -95,5 +95,5 @@ bundle exec jekyll \
  --strict_front_matter \
  --trace \
  --config "_config.yml,_config-$JEKYLL_ENV.yml" \
- "$@"
+ "$@" \
  JEKYLL_ENV="$JEKYLL_ENV"


### PR DESCRIPTION
A missing \ was preventing any error status from the Jekyll build to get returned.