### PR TITLE
Changing nokogiri version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ ENV RUBY_GEMS \
  # Used by devicetree.org, op-tee.org
  mini_magick:4.9.3 \
  # Used by connect.linaro.org, linaro.cloud, linaro.org
- nokogiri:1.10.3 \
+ nokogiri:1.10.4 \
  # Used by staging.lkft.linaro.org
  seriously_simple_static_starter:0.7.0
 LABEL org.linaro.gems=${RUBY_GEMS}


### PR DESCRIPTION
Fixes CVE-2019-5477 (https://nvd.nist.gov/vuln/detail/CVE-2019-5477)