### PR TITLE
Updated jumbo-jekyll-theme versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,16 +129,13 @@ ENV RUBY_GEMS \
  jumbo-jekyll-theme:3.9.4 \
  # Used by staging.96boards.ai
  jumbo-jekyll-theme:5.3.4 \
- # Used by staging.connect.linaro.org
- jumbo-jekyll-theme:5.6.3 \
+ # Used by staging.linaro.org, (staging.)connect.linaro.org
  jumbo-jekyll-theme:5.6.4 \
  # Used by 96boards.org
  jumbo-jekyll-theme:5.5.3 \
- # Used by connect.linaro.org, devicetree.org, linaro.cloud, linaro.org,
+ # Used by devicetree.org, linaro.cloud, linaro.org,
  # mlplatform.org, op-tee.org, trustedfirmware.org,
  jumbo-jekyll-theme:5.5.1 \
- # Used by staging.linaro.org
- jumbo-jekyll-theme:5.5.5 \
  # Used by devicetree.org, op-tee.org
  mini_magick:4.9.3 \
  # Used by connect.linaro.org, linaro.cloud, linaro.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ ENV RUBY_GEMS \
  # Used by staging.lkft.linaro.org
  seriously_simple_static_starter:0.7.0 \
  # Gems staged for removal
- jumbo-jekyll-theme:5.5.5 \
+ jumbo-jekyll-theme:5.5.5
 
 LABEL org.linaro.gems=${RUBY_GEMS}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,10 @@ ENV RUBY_GEMS \
  # Used by connect.linaro.org, linaro.cloud, linaro.org
  nokogiri:1.10.4 \
  # Used by staging.lkft.linaro.org
- seriously_simple_static_starter:0.7.0
+ seriously_simple_static_starter:0.7.0 \
+ # Gems staged for removal
+ jumbo-jekyll-theme:5.5.5 \
+
 LABEL org.linaro.gems=${RUBY_GEMS}
 
 RUN gem install --no-document \


### PR DESCRIPTION
Updated jumbo-jekyll-theme versions
- staging.linaro.org -> 5.6.4
- connect.linaro.org -> 5.6.4

Added previous version (5.5.5) used by staging.linaro.org so tests pass :) 