### PR TITLE
Updated theme version for staging.linaro.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,9 @@ ENV RUBY_GEMS \
  # Used by connect.linaro.org, linaro.cloud, linaro.org
  nokogiri:1.10.4 \
  # Used by staging.lkft.linaro.org
- seriously_simple_static_starter:0.7.0
+ seriously_simple_static_starter:0.7.0 \
+ # Staged for removal (ensures builds pass)
+ jumbo-jekyll-theme:5.5.5 
 LABEL org.linaro.gems=${RUBY_GEMS}
 
 RUN gem install --no-document \

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ ENV RUBY_GEMS \
  # mlplatform.org, op-tee.org, trustedfirmware.org,
  jumbo-jekyll-theme:5.5.1 \
  # Used by staging.linaro.org
- jumbo-jekyll-theme:5.5.5 \
+ jumbo-jekyll-theme:5.6.5 \
  # Used by devicetree.org, op-tee.org
  mini_magick:4.9.3 \
  # Used by connect.linaro.org, linaro.cloud, linaro.org


### PR DESCRIPTION
- Updated theme version for staging.linaro.org
- Added 5.5.5 to *staged for removal* section so that jekyll-build-container tests pass