### PR TITLE
Remove lockfile from correct directory

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -285,8 +285,8 @@ check_Gemfile() {
 # If there is a Gemfile.lock, delete it because it may reference child-gems
 # that the build container doesn't have installed.
 remove_Gem_lockfile() {
-    if [ -f "Gemfile.lock" ]; then
-        rm Gemfile.lock
+    if [ -f "$SOURCE_DIR/Gemfile.lock" ]; then
+        rm "$SOURCE_DIR/Gemfile.lock"
     fi
 }
 


### PR DESCRIPTION
It wasn't updated to support multi-repo builds and so wasn't deleting the correct lockfile in those situations, sometimes causing the build to fail.