### PR TITLE
Updated Jekyll theme version for robots.txt fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ ENV RUBY_GEMS \
  # Used by 96boards.org
  jekyll-toc:0.12.1 \
  # Used by all Jekyll sites
- jumbo-jekyll-theme:5.6.6 \
+ jumbo-jekyll-theme:5.6.9.2 \
  # Used by devicetree.org, op-tee.org
  mini_magick:4.9.3 \
  # Used by connect.linaro.org, linaro.cloud, linaro.org
@@ -132,6 +132,7 @@ ENV RUBY_GEMS \
  # Used by (staging.)lkft.linaro.org
  seriously_simple_static_starter:0.7.0 \
  # Staged for removal (ensures builds pass)
+ jumbo-jekyll-theme:5.6.6 \ 
  jumbo-jekyll-theme:5.6.5
 LABEL org.linaro.gems=${RUBY_GEMS}
 


### PR DESCRIPTION
 This PR adds the new theme version which disables the jekyll-sitemap plugin 'out of the box' for it to only be enabled on production builds in the _config-production.yml config.