### PR TITLE
Adding new linaro-jekyll-theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,7 @@ ENV RUBY_GEMS \
  # Used by (staging.)lkft.linaro.org
  seriously_simple_static_starter:0.7.0 \
  # Jumbo-jekyll-theme latest version
+ linaro-jekyll-theme:4.0.0 \
  jumbo-jekyll-theme:6.0.2.1 \
  closure-compiler \
  # Staged for removal (ensures builds pass)

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ ENV RUBY_GEMS \
  # Used by (staging.)lkft.linaro.org
  seriously_simple_static_starter:0.7.0 \
  # Jumbo-jekyll-theme latest version
- linaro-jekyll-theme:4.0.0 \
+ linaro-jekyll-theme:4.0.1 \
  jumbo-jekyll-theme:6.0.2.1 \
  closure-compiler \
  # Staged for removal (ensures builds pass)


### PR DESCRIPTION
Adding new linaro-jekyll-theme available at:
https://github.com/linaro-marketing/linaro-jekyll-theme
With the documentation here:
https://linaro-jekyll-theme.readthedocs.io/en/latest/
