### PR TITLE
Added jekyll-titles-from-headings plugin for pure markdown docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,9 @@ ENV RUBY_GEMS \
  mini_magick:4.9.3 \
  # Used by connect.linaro.org, linaro.cloud, linaro.org
  nokogiri:1.10.4 \
+ # Pull titles from markdown files.
+ # Useful for documentation repo's that need to stay as pure markdown files.
+ jekyll-titles-from-headings:0.5.3 \
  # Used by (staging.)lkft.linaro.org
  seriously_simple_static_starter:0.7.0 \
  # linaro-jekyll-theme latest versions


### PR DESCRIPTION
Added jekyll-titles-from-headings plugin for pure markdown docs